### PR TITLE
subdivide by plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "halfedge"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "three-d",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,27 +19,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "android-activity"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c77a0045eda8b888c76ea473c2b0515ba6f471d318f8927c5c72240937035a6"
+checksum = "64529721f27c2314ced0890ce45e469574a73e5e6fdd6e9da1860eb29285f5e0"
 dependencies = [
  "android-properties",
  "bitflags",
@@ -50,7 +48,7 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "num_enum",
+ "num_enum 0.6.1",
 ]
 
 [[package]]
@@ -76,21 +74,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
-
-[[package]]
-name = "atomic_refcell"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d6dc922a2792b006573f60b2648076355daeae5ce9cb59507e5908c9625d31"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "autocfg"
@@ -99,10 +85,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.21.2"
+name = "backtrace"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -140,32 +135,12 @@ name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]
 
 [[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "calloop"
@@ -183,11 +158,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -252,13 +228,12 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
+checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
 dependencies = [
  "bitflags",
  "core-foundation",
- "foreign-types",
  "libc",
 ]
 
@@ -299,103 +274,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "ecolor"
-version = "0.21.0"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f99fe3cac305af9d6d92971af60d0f7ea4d783201ef1673571567b6699964d9"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "egui"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6412a21e0bde7c0918f7fb44bbbb86b5e1f88e63c026a4e747cc7af02f76dfbe"
-dependencies = [
- "ahash",
- "epaint",
- "nohash-hasher",
-]
-
-[[package]]
-name = "egui_glow"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8257332fb168a965b3dca81d6a344e053153773c889cabdba0b3b76f1629ae81"
-dependencies = [
- "bytemuck",
- "egui",
- "glow",
- "memoffset",
- "tracing",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "emath"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ecd80612937e0267909d5351770fe150004e24dab93954f69ca62eecd3f77e"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "epaint"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e78b5c58a1f7f621f9d546add2adce20636422c9b251e29f749e8a2f713c95"
-dependencies = [
- "ab_glyph",
- "ahash",
- "atomic_refcell",
- "bytemuck",
- "ecolor",
- "emath",
- "nohash-hasher",
- "parking_lot",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fdeflate"
@@ -417,12 +299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,65 +314,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.0"
+name = "gimli"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
-
-[[package]]
-name = "futures-task"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
-
-[[package]]
-name = "futures-util"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi",
- "wasm-bindgen",
-]
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "gl_generator"
@@ -511,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807edf58b70c0b5b2181dd39fe1839dbdb3ba02645630dc5f753e23da307f762"
+checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -523,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.30.8"
+version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f9b771a65f0a1e3ddb6aa16f867d87dc73c922411c255e6c4ab7f6d45c7327"
+checksum = "8fc93b03242719b8ad39fb26ed2b01737144ce7bd4bfc7adadcef806596760fe"
 dependencies = [
  "bitflags",
  "cfg_aliases",
@@ -546,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "glutin_egl_sys"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3bcbddc51573b977fc6dca5d93867e4f29682cdbaf5d13e48f4fa4346d4d87"
+checksum = "af784eb26c5a68ec85391268e074f0aa618c096eadb5d6330b0911cf34fe57c5"
 dependencies = [
  "gl_generator",
  "windows-sys 0.45.0",
@@ -574,30 +395,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
 dependencies = [
+ "cfg-if",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -608,120 +411,29 @@ name = "halfedge"
 version = "0.1.0"
 dependencies = [
  "three-d",
- "three-d-asset 0.5.0",
  "tokio",
  "winit",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
-name = "http"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "hyper"
-version = "0.14.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
@@ -736,29 +448,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
-
-[[package]]
-name = "itoa"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jni-sys"
@@ -797,33 +486,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical"
-version = "5.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f404a90a744e32e8be729034fc33b90cf2a56418fbf594d69aa3c0214ad414e5"
-dependencies = [
- "cfg-if",
- "lexical-core",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -850,22 +516,6 @@ name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -898,12 +548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,24 +576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,7 +584,7 @@ dependencies = [
  "bitflags",
  "jni-sys",
  "ndk-sys",
- "num_enum",
+ "num_enum 0.5.11",
  "raw-window-handle",
  "thiserror",
 ]
@@ -1004,12 +630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
@@ -1031,11 +651,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1045,7 +665,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -1058,6 +687,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1087,60 +728,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "openssl"
-version = "0.10.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "orbclient"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221d488cd70617f1bd599ed8ceb659df2147d9393717954d82a0f5e8032a6ab1"
+checksum = "8378ac0dfbd4e7895f2d2c1f1345cab3836910baf3a300b000d04250f0c8428f"
 dependencies = [
  "redox_syscall",
 ]
@@ -1155,29 +761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.48.0",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,15 +768,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pkg-config"
@@ -1226,18 +803,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -1258,82 +835,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.11.18"
+name = "rustc-demangle"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "schannel"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
-dependencies = [
- "windows-sys 0.42.0",
-]
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sctk-adwaita"
@@ -1349,33 +860,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -1393,52 +881,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.96"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
-
-[[package]]
-name = "slab"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
-dependencies = [
- "autocfg",
-]
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slotmap"
@@ -1451,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -1475,22 +931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1519,48 +959,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
-dependencies = [
- "autocfg",
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "three-d"
 version = "0.16.0"
-source = "git+https://github.com/asny/three-d.git?rev=afba8c4#afba8c4093eda251dbc08c810782612a421f1846"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a67e2ff0b35f26a54e692d2704c8be11a9632af360ea974150e97e1540aaa5"
 dependencies = [
  "cgmath",
- "egui",
- "egui_glow",
- "getrandom",
  "glow",
  "glutin",
  "instant",
@@ -1568,7 +992,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "thiserror",
- "three-d-asset 0.6.0",
+ "three-d-asset",
  "wasm-bindgen",
  "web-sys",
  "winit",
@@ -1576,22 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "three-d-asset"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956087dd69f4260271faf7c002f5bd1832bef7faddce95408f1da9714ae1d970"
-dependencies = [
- "cgmath",
- "half",
- "reqwest",
- "thiserror",
- "wavefront_obj",
- "web-sys",
-]
-
-[[package]]
-name = "three-d-asset"
 version = "0.6.0"
-source = "git+https://github.com/asny/three-d-asset#6e738cea54c1b2f9d2d4461eb6724244812c0734"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9959d4427b63958661828008f7470d6a8d2c0945b3df0dc7377d6aca38fb694"
 dependencies = [
  "cgmath",
  "half",
@@ -1606,7 +1017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8493a203431061e901613751931f047d1971337153f96d0e5e363d6dbf6a67"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.3",
+ "arrayvec",
  "bytemuck",
  "cfg-if",
  "png",
@@ -1625,35 +1036,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "2d3ce25f50619af8b0aec2eb23deebe84249e19e2ddd393a6e16e3300a6dadfd"
 dependencies = [
- "autocfg",
- "bytes",
- "libc",
- "mio",
+ "backtrace",
  "num_cpus",
  "pin-project-lite",
- "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1664,44 +1055,20 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1709,80 +1076,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
-name = "tracing"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
-dependencies = [
- "cfg-if",
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
 name = "ttf-parser"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dcf002ae3b32cd25400d6df128c5babec3927cd1eb7ce813cfff20eb6c3746"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "url"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vec_map"
@@ -1795,16 +1098,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "want"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-dependencies = [
- "log",
- "try-lock",
-]
 
 [[package]]
 name = "wasi"
@@ -1833,20 +1126,8 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1867,7 +1148,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1877,15 +1158,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "wavefront_obj"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44bbcea20221556597a89462dba84fd4a1ece9a56ab9ec017f872f33b34e8a"
-dependencies = [
- "lexical",
-]
 
 [[package]]
 name = "wayland-client"
@@ -2006,21 +1278,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -2034,7 +1291,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -2054,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -2188,20 +1445,11 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "4344c9f03e6918ce61d94ea6b0500964bb42ee9ca9b2c9c8931990e20b481144"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2226,15 +1474,15 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
+checksum = "47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1"
 
 [[package]]
 name = "zerocopy"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+checksum = "f3b9c234616391070b0b173963ebc65a9195068e7ed3731c6edac2ec45ebe106"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -2242,11 +1490,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.3.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+checksum = "8f7f3a471f98d0a61c34322fbbfd10c384b07687f680d4119813713f72308d91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-three-d = { git = "https://github.com/asny/three-d.git", rev = "afba8c4" , features=["egui-gui", "window" ] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-three-d-asset = {version="0.5",features = ["obj", "http"] }
+three-d = { version = "0.16.0", features = ["window"] }
 winit = "0.28.6"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halfedge"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,61 @@
+# This is a configuration file for the bacon tool
+# More info at https://github.com/Canop/bacon
+
+default_job = "check"
+
+[jobs]
+
+[jobs.check]
+command = ["cargo", "check", "--color", "always"]
+need_stdout = false
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets", "--color", "always"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
+[jobs.clippy]
+command = ["cargo", "clippy", "--color", "always"]
+need_stdout = false
+
+[jobs.clippy-all]
+command = ["cargo", "clippy", "--all-targets", "--color", "always"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
+[jobs.test]
+command = ["cargo", "test", "--color", "always"]
+need_stdout = true
+watch = ["tests"]
+
+[jobs.doc]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = false
+
+# if the doc compiles, then it opens in your browser and bacon switches
+# to the previous job
+[jobs.doc-open]
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back" # so that we don't open the browser at each change
+
+# You can run your application and have the result displayed in bacon,
+# *if* it makes sense for this crate. You can run an example the same
+# way. Don't forget the `--color always` part or the errors won't be
+# properly parsed.
+[jobs.run]
+command = ["cargo", "run", "--bin", "plane", "--color", "always"]
+need_stdout = true
+allow_warnings = true
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal prefs.toml file instead.
+[keybindings]
+a = "job:check-all"
+i = "job:initial"
+c = "job:clippy"
+d = "job:doc-open"
+t = "job:test"
+r = "job:run"

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1691276849,
+        "narHash": "sha256-RNnrzxhW38SOFIF6TY/WaX7VB3PCkYFEeRE5YZU+wHw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "5faab29808a2d72f4ee0c44c8e850e4e6ada972f",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1684894917,
-        "narHash": "sha256-kwKCfmliHIxKuIjnM95TRcQxM/4AAEIZ+4A9nDJ6cJs=",
+        "lastModified": 1691374719,
+        "narHash": "sha256-HCodqnx1Mi2vN4f3hjRPc7+lSQy18vRn8xWW68GeQOg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9ea38d547100edcf0da19aaebbdffa2810585495",
+        "rev": "b520a3889b24aaf909e287d19d406862ced9ffc9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,13 @@
           xorg.libXrandr
          ];    
 
+        bacon = pkgs.bacon;
+
+        bacon_script = pkgs.writeScriptBin "bac" ''
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${graphicLibs}
+          ${bacon}/bin/bacon "$@"
+        '';
+        
         cargo_script = pkgs.writeScriptBin "car" ''
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${graphicLibs}
           export PATH=$PATH:${rust}/bin
@@ -35,6 +42,7 @@
           openssl
           pkg-config
           cargo_script
+          bacon_script
           rust
         ];
 
@@ -52,11 +60,10 @@
       {
         devShells.default = mkShell {
           name = "rust graphics env"; 
-          DERP = rust;
           buildInputs = buildDeps ++ utils;
           shellHook = ''
             echo Entering rust env!
-            echo 'use "car" to run cargo with: LD_LIBRARY_PATH+='
+            echo 'use "car" or "bac" to run cargo or bacon with: LD_LIBRARY_PATH='
             echo "    ${graphicLibs}" | sed 's/:/\n    /g'
           '';
         };

--- a/src/bin/plane.rs
+++ b/src/bin/plane.rs
@@ -4,17 +4,12 @@ use halfedge::{Mesh, Plane};
 fn main() {
     let mut mesh1 = Mesh::unit_cube();
     mesh1.concave_triangulate();
+
     let mut mesh2 = mesh1.clone();
-    // let plane = Plane::new([0.5, 0.5, 0.5].into(), [0.0, 0.0, 1.0].into());
-    // mesh2.split_plane(plane);
-    mesh2.divide_edge(0);
-    // mesh2.concave_triangulate();
-    for (face_i, face) in mesh2.face_inds().enumerate() {
-        print!("face{}:", face_i);
-        for i in face {
-            print!(" {}", i);
-        }
-        println!();
-    }
+    let plane = Plane::new([0.5, 0.5, 0.5].into(), [1.0, 0.0, 0.0].into());
+    mesh2.split_plane(plane);
+    mesh2.concave_triangulate();
+    println!("{}", mesh2);
+    println!("{}", mesh2.pretty_face_vecs());
     show_wireframes(vec![mesh1.into(), mesh2.into()]);
 }

--- a/src/bin/plane.rs
+++ b/src/bin/plane.rs
@@ -1,0 +1,9 @@
+use halfedge;
+use halfedge::plot::show_wireframe;
+use halfedge::Mesh;
+
+fn main() {
+    let mut mesh = Mesh::unit_cube();
+    mesh.concave_triangulate();
+    show_wireframe(mesh.into());
+}

--- a/src/bin/plane.rs
+++ b/src/bin/plane.rs
@@ -1,10 +1,20 @@
-use halfedge::plot::show_wireframe;
+use halfedge::plot::show_wireframes;
 use halfedge::{Mesh, Plane};
 
 fn main() {
-    let mut mesh = Mesh::unit_cube();
-    mesh.concave_triangulate();
-    let plane = Plane::new([0.5, 0.5, 0.5].into(), [0.0, 0.0, 1.0].into());
-    mesh.split_plane(plane);
-    show_wireframe(mesh.into());
+    let mut mesh1 = Mesh::unit_cube();
+    mesh1.concave_triangulate();
+    let mut mesh2 = mesh1.clone();
+    // let plane = Plane::new([0.5, 0.5, 0.5].into(), [0.0, 0.0, 1.0].into());
+    // mesh2.split_plane(plane);
+    mesh2.divide_edge(0);
+    // mesh2.concave_triangulate();
+    for (face_i, face) in mesh2.face_inds().enumerate() {
+        print!("face{}:", face_i);
+        for i in face {
+            print!(" {}", i);
+        }
+        println!();
+    }
+    show_wireframes(vec![mesh1.into(), mesh2.into()]);
 }

--- a/src/bin/plane.rs
+++ b/src/bin/plane.rs
@@ -7,7 +7,7 @@ fn main() {
 
     let mut mesh2 = mesh1.clone();
     let plane = Plane::new([0.5, 0.5, 0.5].into(), [1.0, 0.0, 0.0].into());
-    mesh2.split_plane(plane);
+    mesh2.sub_divide_plane(plane);
     mesh2.concave_triangulate();
     println!("{}", mesh2);
     println!("{}", mesh2.pretty_face_vecs());

--- a/src/bin/plane.rs
+++ b/src/bin/plane.rs
@@ -1,9 +1,10 @@
-use halfedge;
 use halfedge::plot::show_wireframe;
-use halfedge::Mesh;
+use halfedge::{Mesh, Plane};
 
 fn main() {
     let mut mesh = Mesh::unit_cube();
     mesh.concave_triangulate();
+    let plane = Plane::new([0.5, 0.5, 0.5].into(), [0.0, 0.0, 1.0].into());
+    mesh.split_plane(plane);
     show_wireframe(mesh.into());
 }

--- a/src/bin/tri.rs
+++ b/src/bin/tri.rs
@@ -19,7 +19,7 @@ fn main() {
     println!("pre{}", mesh);
     mesh.concave_triangulate();
     println!("post{}", mesh);
-    let tris: Vec<Vec<u32>> = mesh.tri_inds().map(|iter| iter.collect()).collect();
+    let tris: Vec<_> = mesh.tri_inds().collect();
     println!("tri {:?}", tris);
     let edge_count: Vec<_> = mesh.face_edge_count().collect();
     println!("{:#?}", edge_count);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ mod mesh;
 pub mod plot;
 
 // pub use display::Mesh;
-pub use mesh::{Mesh, Point};
+pub use mesh::{Coord, Mesh, Plane};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use halfedge::plot::show_wireframes;
+use halfedge::plot::show_wireframe;
 use halfedge::Mesh;
 // use std::thread;
 // use three_d::CpuMesh;
@@ -17,9 +17,9 @@ fn main() {
         [0.0, 1.0, 0.0].into(),
         [1.0, 1.0, 0.0].into(),
         [0.0, 0.0, 0.0].into(),
-        [1.0, 0.0, 0.0].into(),
+        // [1.0, 0.0, 0.0].into(),
     ];
-    let mut faces = vec![vec![1, 3, 4], vec![1, 4, 2]];
+    let mut faces = vec![vec![1, 2, 3]];
 
     // let mut faces = vec![
     //     vec![1, 3, 4],
@@ -38,11 +38,19 @@ fn main() {
     let mesh = Mesh::from_verts_faces(points, faces);
     let mut mesh2 = mesh.clone();
     // mesh2.flip_edge(2);
-    mesh2.split_edge(2);
+    mesh2.divide_edge(2);
     println!("{}", mesh2);
+    mesh2.concave_triangulate();
+    mesh2.verts.last_mut().unwrap().coord.x = -0.1;
+    for verts in mesh2.face_inds() {
+        for v in verts {
+            print!("{} ", v);
+        }
+        println!("");
+    }
     // mesh.plot();
     // show_wireframe(mesh.into());
-    show_wireframes(vec![mesh.into(), mesh2.into()]);
+    show_wireframe(mesh2.into());
 
     // println!("i never run");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,31 +4,13 @@ use halfedge::Mesh;
 // use three_d::CpuMesh;
 
 fn main() {
-    // let points = vec![
-    //     [1.0, 4.0, 0.0],
-    //     [3.0, 4.0, 0.0],
-    //     [0.0, 2.0, 0.0],
-    //     [2.0, 2.0, 0.0],
-    //     [4.0, 2.0, 0.0],
-    //     [1.0, 0.0, 0.0],
-    //     [3.0, 0.0, 0.0],
-    // ];
     let points = vec![
         [0.0, 1.0, 0.0].into(),
         [1.0, 1.0, 0.0].into(),
         [0.0, 0.0, 0.0].into(),
-        // [1.0, 0.0, 0.0].into(),
     ];
     let mut faces = vec![vec![1, 2, 3]];
 
-    // let mut faces = vec![
-    //     vec![1, 3, 4],
-    //     vec![1, 4, 2],
-    //     vec![2, 4, 5],
-    //     vec![3, 6, 4],
-    //     vec![4, 6, 7],
-    //     vec![4, 7, 5],
-    // ];
     for face in faces.iter_mut() {
         for num in face {
             *num -= 1;
@@ -36,25 +18,5 @@ fn main() {
     }
 
     let mesh = Mesh::from_verts_faces(points, faces);
-    let mut mesh2 = mesh.clone();
-    // mesh2.flip_edge(2);
-    mesh2.divide_edge(2);
-    println!("{}", mesh2);
-    mesh2.concave_triangulate();
-    mesh2.verts.last_mut().unwrap().coord.x = -0.1;
-    for verts in mesh2.face_inds() {
-        for v in verts {
-            print!("{} ", v);
-        }
-        println!("");
-    }
-    // mesh.plot();
-    // show_wireframe(mesh.into());
-    show_wireframe(mesh2.into());
-
-    // println!("i never run");
-
-    // hmesh.flip_edge(2);
-    // println!("{}", hmesh);
-    // hmesh.plot();
+    show_wireframe(mesh.into());
 }

--- a/src/mesh/display.rs
+++ b/src/mesh/display.rs
@@ -43,6 +43,19 @@ impl Mesh {
             .collect();
         format!("{}\n{}", header, body)
     }
+
+    pub fn pretty_face_vecs(&self) -> String {
+        let mut s = String::new();
+        for (face_i, face) in self.face_inds().enumerate() {
+            let mut row = format!("f{}:", face_i);
+            for i in face {
+                row += &format!(" {}", i);
+            }
+            row += "\n";
+            s += &row;
+        }
+        s
+    }
 }
 
 impl Vertex {
@@ -84,9 +97,9 @@ impl fmt::Display for HalfEdge {
 impl fmt::Display for Mesh {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "HalfEdges:\n{}", self.pretty_edges())?;
-        writeln!(f, "")?;
+        writeln!(f)?;
         writeln!(f, "Verts:\n{}", self.pretty_verts())?;
-        writeln!(f, "")?;
+        writeln!(f)?;
         writeln!(f, "Faces:\n{}", self.pretty_faces())?;
         Ok(())
     }

--- a/src/mesh/flip.rs
+++ b/src/mesh/flip.rs
@@ -46,7 +46,7 @@ impl Mesh {
             let twin = &mut self.half_edges[twin_id as usize];
             twin.next = twin_prev_id;
             twin.prev = next_id;
-            twin.origin = dbg!(prev_origin);
+            twin.origin = prev_origin;
         }
 
         {

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -64,7 +64,7 @@ impl From<[u32; 5]> for HalfEdge {
 
 #[derive(Clone, Debug)]
 pub struct Mesh {
-    verts: Verts,
+    pub verts: Verts, // TODO make private
     faces: Faces,
     half_edges: HalfEdges,
 }

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -8,14 +8,15 @@ mod traverse;
 mod tri;
 
 // use std::fmt;
-pub use point::Point;
+pub use plane::Plane;
+pub use point::Coord;
 use std::iter;
 
 // type Point = [f64; 3];
 
 #[derive(Debug, Clone)]
 pub struct Vertex {
-    pub coord: Point,
+    pub coord: Coord,
     half_edge: u32,
 }
 
@@ -83,7 +84,7 @@ impl Mesh {
 
 /// # construct new Self
 impl Mesh {
-    pub fn from_verts_faces(points: Vec<Point>, face_list: FaceList) -> Self {
+    pub fn from_verts_faces(points: Vec<Coord>, face_list: FaceList) -> Self {
         let mut half_edges: Vec<HalfEdge> = Vec::new();
         let mut faces = Vec::with_capacity(face_list.len());
 

--- a/src/mesh/plane.rs
+++ b/src/mesh/plane.rs
@@ -160,7 +160,7 @@ impl Plane {
 }
 
 impl Mesh {
-    pub fn split_plane(&mut self, plane: Plane) {
+    pub fn sub_divide_plane(&mut self, plane: Plane) {
         let results: Vec<_> =
             self.faces
                 .iter()

--- a/src/mesh/plane.rs
+++ b/src/mesh/plane.rs
@@ -185,28 +185,40 @@ impl Mesh {
                 })
                 .collect();
 
+        for res in results.iter() {
+            match res {
+                (TriIntersection::EdgeEdge(_, _), v) => println!("EdgeEdge {:?}", v),
+                (TriIntersection::EdgeCoPoint(_, _), v) => println!("Edge {:?}", v),
+                _ => println!("None"),
+            };
+        }
+
         //filter twins
-        let mut split_edges: Vec<u32> = Vec::with_capacity(results.len());
+        let mut split_edges: Vec<u32> = Vec::with_capacity(dbg!(results.len()));
 
         for (res, eids) in results {
             match res {
                 TriIntersection::EdgeEdge(x1, x2) => {
-                    let id1 = x1.id();
+                    let id1 = eids[x1.id() as usize];
                     let twin1 = self.half_edges[id1 as usize].twin.unwrap();
                     let has_id1 = split_edges.contains(&id1) | split_edges.contains(&twin1);
 
                     if !has_id1 {
-                        self.split_edge(eids[id1 as usize], x1.point);
+                        self.split_edge(id1, x1.point);
                         split_edges.push(twin1);
+                    } else {
+                        println!("edge {} already split", id1);
                     }
 
-                    let id2 = x2.id();
+                    let id2 = eids[x2.id() as usize];
                     let twin2 = self.half_edges[id2 as usize].twin.unwrap();
                     let has_id2 = split_edges.contains(&id2) | split_edges.contains(&twin2);
 
                     if !has_id2 {
-                        self.split_edge(eids[id2 as usize], x2.point);
+                        self.split_edge(id2, x2.point);
                         split_edges.push(twin2);
+                    } else {
+                        println!("edge {} already split", id2);
                     }
                 }
                 TriIntersection::EdgeCoPoint(x, _) => {
@@ -222,6 +234,7 @@ impl Mesh {
                 _ => {}
             }
         }
+        dbg!(split_edges);
     }
 }
 

--- a/src/mesh/plane.rs
+++ b/src/mesh/plane.rs
@@ -12,7 +12,7 @@ enum TriIntersection {
     CoplanarEdge(Point, Point),
     CoplanarPoint(Point),
     EdgeEdge(Point, Point),
-    EdgePoint(Point, Point),
+    EdgeCoPoint(Point, Point),
     None,
 }
 
@@ -20,18 +20,28 @@ impl Plane {
     pub fn new(origin: Point, normal: Point) -> Plane {
         Plane { origin, normal }
     }
-    /// assums self.normal is normalized
+    /// assumes self.normal is normalized
     pub fn dist(&self, p: Point) -> f64 {
         let prod = self.normal * p;
         let diff = prod - self.origin;
         diff.iter().sum()
     }
 
+    /// assumes one edge point on either side of self
+    fn edge_intersect(&self, edge: [Point; 2]) -> Point {
+        let edge_dir = edge[1] - edge[0];
+        let o_dist = self.origin - edge[0];
+        let dot1: f64 = (o_dist * self.normal).into_iter().sum();
+        let dot2: f64 = (self.normal * edge_dir).into_iter().sum();
+        let dist = dot1 / dot2;
+        edge[0] + edge_dir * dist
+    }
+
     pub fn tri_intersect(&self, tri: [Point; 3]) -> TriIntersection {
         let dists = [self.dist(tri[0]), self.dist(tri[1]), self.dist(tri[2])];
         let ge = [dists[0] > 0.0, dists[1] > 0.0, dists[2] > 0.0];
         let eq = [dists[0] == 0.0, dists[1] == 0.0, dists[2] == 0.0];
-        let le = [!(ge[0] | eq[0]), !(ge[1] | eq[1]), !(ge[2] | eq[2])];
+        // let le = [!(ge[0] | eq[0]), !(ge[1] | eq[1]), !(ge[2] | eq[2])];
 
         let eq_sum = eq.iter().map(|b| if *b { 1 } else { 0 }).sum::<u8>();
         let ge_sum = ge.iter().map(|b| if *b { 1 } else { 0 }).sum::<u8>();
@@ -51,12 +61,19 @@ impl Plane {
             (_, 3) => TriIntersection::None,
             (0, 0) => TriIntersection::None,
             (1, 0 | 2) => TriIntersection::CoplanarPoint(copoints.next().unwrap()),
-            (1, 1) => TriIntersection::CoplanarEdge(todo!(), todo!()),
+            (1, 1) => TriIntersection::EdgeCoPoint(todo!(), todo!()),
             (0, 2) => TriIntersection::EdgeEdge(todo!(), todo!()),
             (0, 1) => TriIntersection::EdgeEdge(todo!(), todo!()),
-
             (4.., _) => panic!("unreachable"),
             (_, 4..) => panic!("unreachable"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_edge_dist() {
+        todo!()
     }
 }

--- a/src/mesh/plane.rs
+++ b/src/mesh/plane.rs
@@ -1,3 +1,5 @@
+use core::panic;
+
 use crate::Point;
 
 struct Plane {
@@ -5,11 +7,56 @@ struct Plane {
     normal: Point,
 }
 
+enum TriIntersection {
+    CoplanarFace,
+    CoplanarEdge(Point, Point),
+    CoplanarPoint(Point),
+    EdgeEdge(Point, Point),
+    EdgePoint(Point, Point),
+    None,
+}
+
 impl Plane {
+    pub fn new(origin: Point, normal: Point) -> Plane {
+        Plane { origin, normal }
+    }
     /// assums self.normal is normalized
     pub fn dist(&self, p: Point) -> f64 {
         let prod = self.normal * p;
         let diff = prod - self.origin;
         diff.iter().sum()
+    }
+
+    pub fn tri_intersect(&self, tri: [Point; 3]) -> TriIntersection {
+        let dists = [self.dist(tri[0]), self.dist(tri[1]), self.dist(tri[2])];
+        let ge = [dists[0] > 0.0, dists[1] > 0.0, dists[2] > 0.0];
+        let eq = [dists[0] == 0.0, dists[1] == 0.0, dists[2] == 0.0];
+        let le = [!(ge[0] | eq[0]), !(ge[1] | eq[1]), !(ge[2] | eq[2])];
+
+        let eq_sum = eq.iter().map(|b| if *b { 1 } else { 0 }).sum::<u8>();
+        let ge_sum = ge.iter().map(|b| if *b { 1 } else { 0 }).sum::<u8>();
+        // let le_sum = le.iter().map(|b| if *b { 1 } else { 0 }).sum::<u8>();
+
+        let mut copoints = eq
+            .iter()
+            .enumerate()
+            .filter_map(|(i, b)| if *b { Some(tri[i]) } else { None });
+
+        match (eq_sum, ge_sum) {
+            (3, _) => TriIntersection::CoplanarFace,
+
+            (2, _) => {
+                TriIntersection::CoplanarEdge(copoints.next().unwrap(), copoints.next().unwrap())
+            }
+            (_, 3) => TriIntersection::None,
+            (0, 0) => TriIntersection::None,
+            (1, 0 | 2) => TriIntersection::CoplanarPoint(copoints.next().unwrap()),
+            (1, 1) => TriIntersection::CoplanarEdge(todo!(), todo!()),
+            (0, 2) => TriIntersection::EdgeEdge(todo!(), todo!()),
+            (0, 1) => TriIntersection::EdgeEdge(todo!(), todo!()),
+
+            (4.., _) => panic!("unreachable"),
+            (_, 4..) => panic!("unreachable"),
+        }
     }
 }

--- a/src/mesh/plane.rs
+++ b/src/mesh/plane.rs
@@ -194,7 +194,7 @@ impl Mesh {
         }
 
         //filter twins
-        let mut split_edges: Vec<u32> = Vec::with_capacity(dbg!(results.len()));
+        let mut split_edges: Vec<u32> = Vec::with_capacity(results.len());
 
         for (res, eids) in results {
             match res {
@@ -206,8 +206,6 @@ impl Mesh {
                     if !has_id1 {
                         self.divide_edge_at(id1, x1.point);
                         split_edges.push(twin1);
-                    } else {
-                        println!("edge {} already split", id1);
                     }
 
                     let id2 = eids[x2.id() as usize];
@@ -217,8 +215,6 @@ impl Mesh {
                     if !has_id2 {
                         self.divide_edge_at(id2, x2.point);
                         split_edges.push(twin2);
-                    } else {
-                        println!("edge {} already split", id2);
                     }
                 }
                 TriIntersection::EdgeCoPoint(x, _) => {

--- a/src/mesh/plane.rs
+++ b/src/mesh/plane.rs
@@ -1,69 +1,149 @@
 use core::panic;
 
-use crate::Point;
+use crate::Coord;
 
-struct Plane {
-    origin: Point,
-    normal: Point,
+pub struct Plane {
+    origin: Coord,
+    normal: Coord,
 }
 
-enum TriIntersection {
+type LocalVertex = u32;
+
+type LocalEdge = [LocalVertex; 2];
+
+#[derive(Debug, PartialEq)]
+pub struct EdgeIntersection {
+    edge: LocalEdge,
+    point: Coord,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum TriIntersection {
     CoplanarFace,
-    CoplanarEdge(Point, Point),
-    CoplanarPoint(Point),
-    EdgeEdge(Point, Point),
-    EdgeCoPoint(Point, Point),
+    CoplanarEdge(LocalEdge),
+    CoplanarPoint(LocalVertex),
+    EdgeEdge(EdgeIntersection, EdgeIntersection),
+    EdgeCoPoint(EdgeIntersection, LocalVertex),
     None,
 }
 
 impl Plane {
-    pub fn new(origin: Point, normal: Point) -> Plane {
+    pub fn new(origin: Coord, normal: Coord) -> Plane {
         Plane { origin, normal }
     }
     /// assumes self.normal is normalized
-    pub fn dist(&self, p: Point) -> f64 {
+    pub fn dist(&self, p: Coord) -> f64 {
         let prod = self.normal * p;
         let diff = prod - self.origin;
         diff.iter().sum()
     }
 
-    /// assumes one edge point on either side of self
-    fn edge_intersect(&self, edge: [Point; 2]) -> Point {
-        let edge_dir = edge[1] - edge[0];
-        let o_dist = self.origin - edge[0];
-        let dot1: f64 = (o_dist * self.normal).into_iter().sum();
-        let dot2: f64 = (self.normal * edge_dir).into_iter().sum();
-        let dist = dot1 / dot2;
-        edge[0] + edge_dir * dist
+    /// assumes l.dot(self.normal) != 0
+    /// where l is a line direcetion vector
+    fn happy_line_intersect(&self, l0: Coord, l1: Coord) -> Coord {
+        // plane dist = (x-p0).dot(n)
+        // points on plane: (x-p0).dot(n)=0
+        // points on line = l0 + s*l
+        // intersection_points: (l0 + s*l - p0).dot(n) = 0
+        // s = (p0 - l0).dot(n) / l.dot(n)
+        // intersection = l0 + s*l
+        let l = l1 - l0;
+        let n = self.normal;
+        let s = (self.origin - l0).dot(n) / l.dot(n);
+        l0 + l * s
     }
 
-    pub fn tri_intersect(&self, tri: [Point; 3]) -> TriIntersection {
+    pub fn tri_intersect(&self, tri: [Coord; 3]) -> TriIntersection {
         let dists = [self.dist(tri[0]), self.dist(tri[1]), self.dist(tri[2])];
         let ge = [dists[0] > 0.0, dists[1] > 0.0, dists[2] > 0.0];
         let eq = [dists[0] == 0.0, dists[1] == 0.0, dists[2] == 0.0];
-        // let le = [!(ge[0] | eq[0]), !(ge[1] | eq[1]), !(ge[2] | eq[2])];
+        let le = [!(ge[0] | eq[0]), !(ge[1] | eq[1]), !(ge[2] | eq[2])];
 
         let eq_sum = eq.iter().map(|b| if *b { 1 } else { 0 }).sum::<u8>();
         let ge_sum = ge.iter().map(|b| if *b { 1 } else { 0 }).sum::<u8>();
-        // let le_sum = le.iter().map(|b| if *b { 1 } else { 0 }).sum::<u8>();
 
         let mut copoints = eq
             .iter()
             .enumerate()
-            .filter_map(|(i, b)| if *b { Some(tri[i]) } else { None });
+            .filter_map(|(i, b)| if *b { Some(i as u32) } else { None });
+
+        let mut gepoints = ge
+            .iter()
+            .enumerate()
+            .filter_map(|(i, b)| if *b { Some(i as u32) } else { None });
+
+        let mut lepoints = le
+            .iter()
+            .enumerate()
+            .filter_map(|(i, b)| if *b { Some(i as u32) } else { None });
 
         match (eq_sum, ge_sum) {
             (3, _) => TriIntersection::CoplanarFace,
 
             (2, _) => {
-                TriIntersection::CoplanarEdge(copoints.next().unwrap(), copoints.next().unwrap())
+                TriIntersection::CoplanarEdge([copoints.next().unwrap(), copoints.next().unwrap()])
             }
-            (_, 3) => TriIntersection::None,
-            (0, 0) => TriIntersection::None,
+            (_, 3) | (0, 0) => TriIntersection::None,
             (1, 0 | 2) => TriIntersection::CoplanarPoint(copoints.next().unwrap()),
-            (1, 1) => TriIntersection::EdgeCoPoint(todo!(), todo!()),
-            (0, 2) => TriIntersection::EdgeEdge(todo!(), todo!()),
-            (0, 1) => TriIntersection::EdgeEdge(todo!(), todo!()),
+            (1, 1) => {
+                let ids: [LocalVertex; 2] = [gepoints.next().unwrap(), lepoints.next().unwrap()];
+                let coords = [tri[ids[0] as usize], tri[ids[1] as usize]];
+                TriIntersection::EdgeCoPoint(
+                    EdgeIntersection {
+                        edge: ids,
+                        point: self.happy_line_intersect(coords[0], coords[1]),
+                    },
+                    copoints.next().unwrap(),
+                )
+            }
+            (0, 2) => {
+                let low_id = lepoints.next().unwrap();
+                let low_point = tri[low_id as usize];
+
+                let high_id1 = gepoints.next().unwrap();
+                let high_id2 = gepoints.next().unwrap();
+                let hight_point1 = tri[high_id1 as usize];
+                let hight_point2 = tri[high_id2 as usize];
+
+                let loc_edge1 = [low_id, high_id1];
+                let loc_edge2 = [low_id, high_id2];
+
+                let intersect1 = EdgeIntersection {
+                    edge: loc_edge1,
+                    point: self.happy_line_intersect(low_point, hight_point1),
+                };
+
+                let intersect2 = EdgeIntersection {
+                    edge: loc_edge2,
+                    point: self.happy_line_intersect(low_point, hight_point2),
+                };
+
+                TriIntersection::EdgeEdge(intersect1, intersect2)
+            }
+            (0, 1) => {
+                let high_id = gepoints.next().unwrap();
+                let high_point = tri[high_id as usize];
+
+                let low_id1 = lepoints.next().unwrap();
+                let low_id2 = lepoints.next().unwrap();
+                let low_point1 = tri[low_id1 as usize];
+                let low_point2 = tri[low_id2 as usize];
+
+                let loc_edge1 = [low_id1, high_id];
+                let loc_edge2 = [low_id2, high_id];
+
+                let intersect1 = EdgeIntersection {
+                    edge: loc_edge1,
+                    point: self.happy_line_intersect(high_point, low_point1),
+                };
+
+                let intersect2 = EdgeIntersection {
+                    edge: loc_edge2,
+                    point: self.happy_line_intersect(high_point, low_point2),
+                };
+
+                TriIntersection::EdgeEdge(intersect1, intersect2)
+            }
             (4.., _) => panic!("unreachable"),
             (_, 4..) => panic!("unreachable"),
         }
@@ -72,8 +152,37 @@ impl Plane {
 
 #[cfg(test)]
 mod tests {
+    use super::{EdgeIntersection, Plane, TriIntersection};
+
     #[test]
-    fn test_edge_dist() {
-        todo!()
+    fn test_tri_intersect() {
+        let plane_origin = [0.0, 0.0, 0.0];
+        let z_axis = [0.0, 0.0, 1.0];
+        let plane = Plane::new(plane_origin.into(), z_axis.into());
+
+        let co_tri = [
+            [0.0, 0.0, 0.0].into(),
+            [0.0, 0.0, 0.0].into(),
+            [0.0, 0.0, 0.0].into(),
+        ];
+        let res = plane.tri_intersect(co_tri);
+        assert_eq!(res, TriIntersection::CoplanarFace);
+
+        let bisect_tri = [
+            [1.0, 0.0, 1.0].into(),
+            [0.0, 0.0, 0.0].into(),
+            [0.0, 0.0, -1.0].into(),
+        ];
+        let res = plane.tri_intersect(bisect_tri);
+        assert_eq!(
+            res,
+            TriIntersection::EdgeCoPoint(
+                EdgeIntersection {
+                    edge: [0, 2],
+                    point: [0.5, 0., 0.].into()
+                },
+                1
+            )
+        );
     }
 }

--- a/src/mesh/plane.rs
+++ b/src/mesh/plane.rs
@@ -204,7 +204,7 @@ impl Mesh {
                     let has_id1 = split_edges.contains(&id1) | split_edges.contains(&twin1);
 
                     if !has_id1 {
-                        self.split_edge(id1, x1.point);
+                        self.divide_edge_at(id1, x1.point);
                         split_edges.push(twin1);
                     } else {
                         println!("edge {} already split", id1);
@@ -215,7 +215,7 @@ impl Mesh {
                     let has_id2 = split_edges.contains(&id2) | split_edges.contains(&twin2);
 
                     if !has_id2 {
-                        self.split_edge(id2, x2.point);
+                        self.divide_edge_at(id2, x2.point);
                         split_edges.push(twin2);
                     } else {
                         println!("edge {} already split", id2);
@@ -227,7 +227,7 @@ impl Mesh {
                     let has_id = split_edges.contains(&id) | split_edges.contains(&twin);
 
                     if !has_id {
-                        self.split_edge(eids[id as usize], x.point);
+                        self.divide_edge_at(eids[id as usize], x.point);
                         split_edges.push(twin);
                     }
                 }

--- a/src/mesh/plane.rs
+++ b/src/mesh/plane.rs
@@ -1,7 +1,4 @@
-use crate::{
-    mesh::{traverse, HalfEdge},
-    Coord, Mesh,
-};
+use crate::{Coord, Mesh};
 
 pub struct Plane {
     origin: Coord,
@@ -167,8 +164,7 @@ impl Mesh {
         let results: Vec<_> =
             self.faces
                 .iter()
-                .enumerate()
-                .filter_map(|(face_i, incedent_edge)| {
+                .filter_map(|incedent_edge| {
                     let mut trav = self.get_traverser(*incedent_edge);
                     let eid0 = trav.current_edge;
                     let e0 = trav.get_edge();

--- a/src/mesh/point.rs
+++ b/src/mesh/point.rs
@@ -103,6 +103,17 @@ impl Sub<Point> for Point {
     }
 }
 
+impl Mul<f64> for Point {
+    type Output = Point;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self {
+            x: self.x * rhs,
+            y: self.y * rhs,
+            z: self.z * rhs,
+        }
+    }
+}
 impl Mul<Point> for Point {
     type Output = Point;
 

--- a/src/mesh/point.rs
+++ b/src/mesh/point.rs
@@ -66,6 +66,17 @@ impl<'a> Coord {
         let prod = self * rhs;
         prod.into_iter().sum()
     }
+
+    pub fn norm(self) -> f64 {
+        self.dot(self).sqrt()
+    }
+
+    /// normalize inplace and return the norm
+    pub fn normalize(&mut self) -> f64 {
+        let norm = self.norm();
+        self / norm;
+        norm
+    }
 }
 
 impl<'a> IntoIterator for &'a Coord {
@@ -131,6 +142,15 @@ impl Mul<Coord> for Coord {
     }
 }
 
+impl Div<f64> for &mut Coord {
+    type Output = ();
+
+    fn div(self, rhs: f64) -> Self::Output {
+        self.x /= rhs;
+        self.y /= rhs;
+        self.z /= rhs;
+    }
+}
 impl Div<f64> for Coord {
     type Output = Coord;
     fn div(self, rhs: f64) -> Self::Output {

--- a/src/mesh/point.rs
+++ b/src/mesh/point.rs
@@ -21,9 +21,9 @@ impl From<[f64; 3]> for Coord {
     }
 }
 
-impl Into<[f64; 3]> for Coord {
-    fn into(self) -> [f64; 3] {
-        [self.x, self.y, self.z]
+impl From<Coord> for [f64; 3] {
+    fn from(value: Coord) -> Self {
+        [value.x, value.y, value.z]
     }
 }
 

--- a/src/mesh/point.rs
+++ b/src/mesh/point.rs
@@ -74,7 +74,7 @@ impl<'a> Coord {
     /// normalize inplace and return the norm
     pub fn normalize(&mut self) -> f64 {
         let norm = self.norm();
-        self / norm;
+        self.div_inplace(norm);
         norm
     }
 }
@@ -142,10 +142,8 @@ impl Mul<Coord> for Coord {
     }
 }
 
-impl Div<f64> for &mut Coord {
-    type Output = ();
-
-    fn div(self, rhs: f64) -> Self::Output {
+impl Coord {
+    fn div_inplace(&mut self, rhs: f64) {
         self.x /= rhs;
         self.y /= rhs;
         self.z /= rhs;

--- a/src/mesh/point.rs
+++ b/src/mesh/point.rs
@@ -1,17 +1,17 @@
 use std::ops::{Add, Div, Index, Mul, Sub};
 
-#[derive(Debug, Copy, Clone)]
-pub struct Point {
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Coord {
     pub x: f64,
     pub y: f64,
     pub z: f64,
 }
 
 pub struct PointIter {
-    point: Point,
+    point: Coord,
     index: u8,
 }
-impl From<[f64; 3]> for Point {
+impl From<[f64; 3]> for Coord {
     fn from(value: [f64; 3]) -> Self {
         Self {
             x: value[0],
@@ -21,7 +21,7 @@ impl From<[f64; 3]> for Point {
     }
 }
 
-impl Into<[f64; 3]> for Point {
+impl Into<[f64; 3]> for Coord {
     fn into(self) -> [f64; 3] {
         [self.x, self.y, self.z]
     }
@@ -48,7 +48,7 @@ impl Iterator for PointIter {
         }
     }
 }
-impl IntoIterator for Point {
+impl IntoIterator for Coord {
     type Item = f64;
     type IntoIter = std::array::IntoIter<f64, 3>;
 
@@ -57,13 +57,18 @@ impl IntoIterator for Point {
     }
 }
 
-impl<'a> Point {
+impl<'a> Coord {
     pub fn iter(&'a self) -> std::array::IntoIter<&'a f64, 3> {
         self.into_iter()
     }
+
+    pub fn dot(self, rhs: Coord) -> f64 {
+        let prod = self * rhs;
+        prod.into_iter().sum()
+    }
 }
 
-impl<'a> IntoIterator for &'a Point {
+impl<'a> IntoIterator for &'a Coord {
     type Item = &'a f64;
     type IntoIter = std::array::IntoIter<Self::Item, 3>;
 
@@ -72,8 +77,8 @@ impl<'a> IntoIterator for &'a Point {
     }
 }
 
-impl Add<f64> for Point {
-    type Output = Point;
+impl Add<f64> for Coord {
+    type Output = Coord;
     fn add(self, rhs: f64) -> Self::Output {
         Self {
             x: self.x + rhs,
@@ -82,9 +87,9 @@ impl Add<f64> for Point {
         }
     }
 }
-impl Add<Point> for Point {
-    type Output = Point;
-    fn add(self, rhs: Point) -> Self::Output {
+impl Add<Coord> for Coord {
+    type Output = Coord;
+    fn add(self, rhs: Coord) -> Self::Output {
         Self {
             x: self.x + rhs.x,
             y: self.y + rhs.y,
@@ -92,19 +97,19 @@ impl Add<Point> for Point {
         }
     }
 }
-impl Sub<Point> for Point {
-    type Output = Point;
-    fn sub(self, rhs: Point) -> Self::Output {
+impl Sub<Coord> for Coord {
+    type Output = Coord;
+    fn sub(self, rhs: Coord) -> Self::Output {
         Self {
-            x: self.x + rhs.x,
-            y: self.y + rhs.y,
-            z: self.z + rhs.z,
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+            z: self.z - rhs.z,
         }
     }
 }
 
-impl Mul<f64> for Point {
-    type Output = Point;
+impl Mul<f64> for Coord {
+    type Output = Coord;
 
     fn mul(self, rhs: f64) -> Self::Output {
         Self {
@@ -114,10 +119,10 @@ impl Mul<f64> for Point {
         }
     }
 }
-impl Mul<Point> for Point {
-    type Output = Point;
+impl Mul<Coord> for Coord {
+    type Output = Coord;
 
-    fn mul(self, rhs: Point) -> Self::Output {
+    fn mul(self, rhs: Coord) -> Self::Output {
         Self {
             x: self.x * rhs.x,
             y: self.y * rhs.y,
@@ -126,8 +131,8 @@ impl Mul<Point> for Point {
     }
 }
 
-impl Div<f64> for Point {
-    type Output = Point;
+impl Div<f64> for Coord {
+    type Output = Coord;
     fn div(self, rhs: f64) -> Self::Output {
         Self {
             x: self.x / rhs,
@@ -137,7 +142,7 @@ impl Div<f64> for Point {
     }
 }
 
-impl Index<usize> for Point {
+impl Index<usize> for Coord {
     type Output = f64;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/src/mesh/primative.rs
+++ b/src/mesh/primative.rs
@@ -1,5 +1,4 @@
 use super::Mesh;
-use super::Point;
 
 impl Mesh {
     pub fn unit_cube() -> Self {

--- a/src/mesh/primative.rs
+++ b/src/mesh/primative.rs
@@ -1,6 +1,16 @@
 use super::Mesh;
 
 impl Mesh {
+    pub fn unit_triangle() -> Self {
+        let points = vec![
+            [0.0, 0.0, 0.0].into(),
+            [1.0, 0.0, 0.0].into(),
+            [1.0, 1.0, 0.0].into(),
+        ];
+        let faces = vec![vec![0, 1, 2]];
+        Mesh::from_verts_faces(points, faces)
+    }
+
     pub fn unit_cube() -> Self {
         let points = vec![
             [0.0, 0.0, 0.0].into(),

--- a/src/mesh/primative.rs
+++ b/src/mesh/primative.rs
@@ -11,6 +11,17 @@ impl Mesh {
         Mesh::from_verts_faces(points, faces)
     }
 
+    pub fn unit_square() -> Self {
+        let points = vec![
+            [0.0, 0.0, 0.0].into(),
+            [1.0, 0.0, 0.0].into(),
+            [1.0, 1.0, 0.0].into(),
+            [0.0, 1.0, 0.0].into(),
+        ];
+        let faces = vec![vec![0, 1, 2, 3]];
+        Mesh::from_verts_faces(points, faces)
+    }
+
     pub fn unit_cube() -> Self {
         let points = vec![
             [0.0, 0.0, 0.0].into(),
@@ -31,7 +42,6 @@ impl Mesh {
             vec![4, 5, 6, 7],
         ];
 
-        let mesh = Mesh::from_verts_faces(points, faces);
-        mesh
+        Mesh::from_verts_faces(points, faces)
     }
 }

--- a/src/mesh/split.rs
+++ b/src/mesh/split.rs
@@ -1,7 +1,18 @@
-use super::{HalfEdge, Mesh, Vertex};
+use super::{HalfEdge, Mesh, Point, Vertex};
 
 impl Mesh {
-    pub fn split_edge(&mut self, edge_id: u32) {
+    /// split_edge with mid point
+    pub fn divide_edge(&mut self, edge_id: u32) {
+        let mut travler = self.get_traverser(edge_id);
+        let id1 = travler.get_edge().origin;
+        let p1 = self.verts[id1 as usize].coord;
+        travler.next();
+        let id2 = travler.get_edge().origin;
+        let p2 = self.verts[id2 as usize].coord;
+        let mid = (p1 + p2) / 2.0;
+        self.split_edge(edge_id, mid);
+    }
+    pub fn split_edge(&mut self, edge_id: u32, coord: Point) {
         // get all effected ids
         let travler = self.get_traverser(edge_id);
         let mut twin_travler = travler.clone();
@@ -18,17 +29,11 @@ impl Mesh {
 
         let edge = &self.half_edges[edge_id as usize];
         let twin = &self.half_edges[twin_id as usize];
-        let origin_id = edge.origin;
-        let twin_origin_id = twin.origin;
 
         // create split point
-        let new_point = {
-            let p1 = &self.verts[origin_id as usize];
-            let p2 = &self.verts[twin_origin_id as usize];
-            Vertex {
-                coord: p1.coord / 2.0 + p2.coord / 2.0,
-                half_edge: new_edge_id,
-            }
+        let new_point = Vertex {
+            coord,
+            half_edge: new_edge_id,
         };
         self.verts.push(new_point);
 

--- a/src/mesh/split.rs
+++ b/src/mesh/split.rs
@@ -10,9 +10,9 @@ impl Mesh {
         let id2 = travler.get_edge().origin;
         let p2 = self.verts[id2 as usize].coord;
         let mid = (p1 + p2) / 2.0;
-        self.split_edge(edge_id, mid);
+        self.divide_edge_at(edge_id, mid);
     }
-    pub fn split_edge(&mut self, edge_id: u32, coord: Coord) {
+    pub fn divide_edge_at(&mut self, edge_id: u32, coord: Coord) {
         // get all effected ids
         let mut travler = self.get_traverser(edge_id);
         let mut twin_travler = travler.clone();

--- a/src/mesh/split.rs
+++ b/src/mesh/split.rs
@@ -14,13 +14,13 @@ impl Mesh {
     }
     pub fn split_edge(&mut self, edge_id: u32, coord: Coord) {
         // get all effected ids
-        let travler = self.get_traverser(edge_id);
+        let mut travler = self.get_traverser(edge_id);
         let mut twin_travler = travler.clone();
         let twin_id = twin_travler.twin().get_id();
-        // let twin_next_id = twin_travler.clone().next().get_id();
+        let twin_next_id = twin_travler.next().get_id();
         // let twin_prev_id = twin_travler.prev().get_id();
 
-        // let next_id = travler.clone().next().get_id();
+        let next_id = travler.next().get_id();
         // let prev_id = travler.prev().get_id();
 
         let new_edge_id = self.half_edges.len() as u32;
@@ -47,8 +47,12 @@ impl Mesh {
             self.half_edges.push(new_twin);
         }
 
-        //update target edge and twin
+        //update target edge and twin to point to new edges
         self.half_edges[edge_id as usize].next = new_edge_id;
         self.half_edges[twin_id as usize].next = new_twin_id;
+
+        // update old nexts.prev
+        self.half_edges[next_id as usize].prev = new_edge_id;
+        self.half_edges[twin_next_id as usize].prev = new_twin_id;
     }
 }

--- a/src/mesh/split.rs
+++ b/src/mesh/split.rs
@@ -1,4 +1,4 @@
-use super::{HalfEdge, Mesh, Point, Vertex};
+use super::{Coord, HalfEdge, Mesh, Vertex};
 
 impl Mesh {
     /// split_edge with mid point
@@ -12,7 +12,7 @@ impl Mesh {
         let mid = (p1 + p2) / 2.0;
         self.split_edge(edge_id, mid);
     }
-    pub fn split_edge(&mut self, edge_id: u32, coord: Point) {
+    pub fn split_edge(&mut self, edge_id: u32, coord: Coord) {
         // get all effected ids
         let travler = self.get_traverser(edge_id);
         let mut twin_travler = travler.clone();

--- a/src/mesh/traverse.rs
+++ b/src/mesh/traverse.rs
@@ -59,6 +59,7 @@ impl<'a> Iterator for FaceEdgesIter<'a> {
         return Some(&self.traverser.get_edge());
     }
 }
+
 pub struct VertexEdgesIter<'a> {
     traverser: MeshTraverser<'a>,
     start_edge: u32,
@@ -112,14 +113,18 @@ impl Mesh {
         self.face_inds().map(|edge_iter| edge_iter.count())
     }
 
-    pub fn tri_inds(&self) -> impl Iterator<Item = impl Iterator<Item = u32> + '_> + '_ {
-        self.faces
-            .iter()
-            .enumerate()
-            .map(|(i, _face)| self.face_edges(i as u32).map(|edge| edge.origin).take(3))
+    pub fn tri_inds(&self) -> impl Iterator<Item = [u32; 3]> + '_ {
+        self.faces.iter().enumerate().map(|(i, _face)| {
+            let mut inds_iter = self.face_edges(i as u32).map(|edge| edge.origin).take(3);
+            [
+                inds_iter.next().expect("atleast 3 vertex per face"),
+                inds_iter.next().expect("atleast 3 vertex per face"),
+                inds_iter.next().expect("atleast 3 vertex per face"),
+            ]
+        })
     }
 
-    pub fn tri_coords(&self) -> impl Iterator<Item = impl Iterator<Item = Coord> + '_> + '_ {
+    pub fn tri_coords(&self) -> impl Iterator<Item = [Coord; 3]> + '_ {
         self.tri_inds()
             .map(|tri_i| tri_i.map(|i| self.verts[i as usize].coord))
     }

--- a/src/mesh/traverse.rs
+++ b/src/mesh/traverse.rs
@@ -1,3 +1,5 @@
+use crate::Coord;
+
 use super::{HalfEdge, Mesh};
 use std::iter::Iterator;
 
@@ -115,6 +117,11 @@ impl Mesh {
             .iter()
             .enumerate()
             .map(|(i, _face)| self.face_edges(i as u32).map(|edge| edge.origin).take(3))
+    }
+
+    pub fn tri_coords(&self) -> impl Iterator<Item = impl Iterator<Item = Coord> + '_> + '_ {
+        self.tri_inds()
+            .map(|tri_i| tri_i.map(|i| self.verts[i as usize].coord))
     }
 
     /// # gets iterator over half edges around a vertex

--- a/src/mesh/traverse.rs
+++ b/src/mesh/traverse.rs
@@ -56,7 +56,7 @@ impl<'a> Iterator for FaceEdgesIter<'a> {
         if self.traverser.current_edge == self.start_edge {
             self.stop = true;
         }
-        return Some(&self.traverser.get_edge());
+        return Some(self.traverser.get_edge());
     }
 }
 
@@ -78,7 +78,7 @@ impl<'a> Iterator for VertexEdgesIter<'a> {
         if self.traverser.current_edge == self.start_edge {
             self.stop = true;
         }
-        return Some(&self.traverser.get_edge());
+        return Some(self.traverser.get_edge());
     }
 }
 

--- a/src/mesh/tri.rs
+++ b/src/mesh/tri.rs
@@ -70,7 +70,7 @@ impl Mesh {
             targets.push(travler.get_id());
             travler.next();
         }
-        for edge_id in dbg!(targets) {
+        for edge_id in targets {
             self.clip_polygon(edge_id);
         }
     }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -47,10 +47,10 @@ impl WireFrame {
             },
         );
         model_material.render_states.cull = Cull::Back;
-        let model = Gm::new(GPUMesh::new(&context, &mesh), model_material);
+        let model = Gm::new(GPUMesh::new(context, &mesh), model_material);
 
         let mut wireframe_material = PhysicalMaterial::new_opaque(
-            &context,
+            context,
             &CpuMaterial {
                 albedo: Color::new_opaque(220, 50, 50),
                 roughness: 0.7,
@@ -65,14 +65,14 @@ impl WireFrame {
             cylinder
                 .transform(&Mat4::from_nonuniform_scale(1.0, 0.007, 0.007))
                 .unwrap();
-            let imesh = InstancedMesh::new(&context, &edge_transformations(&mesh), &cylinder);
+            let imesh = InstancedMesh::new(context, &edge_transformations(&mesh), &cylinder);
             Gm::new(imesh, wireframe_material.clone())
         };
 
         let vertices = {
             let mut sphere = CpuMesh::sphere(8);
             sphere.transform(&Mat4::from_scale(0.015)).unwrap();
-            let imesh = InstancedMesh::new(&context, &vertex_transformations(&mesh), &sphere);
+            let imesh = InstancedMesh::new(context, &vertex_transformations(&mesh), &sphere);
             Gm::new(imesh, wireframe_material)
         };
         WireFrame {
@@ -83,16 +83,15 @@ impl WireFrame {
     }
 }
 
-impl Into<Vector3<f64>> for Coord {
-    fn into(self) -> Vector3<f64> {
-        Vector3::new(self.x, self.y, self.z)
+impl From<Coord> for Vector3<f64> {
+    fn from(value: Coord) -> Self {
+        Vector3::new(value.x, value.y, value.z)
     }
 }
-
-impl Into<CpuMesh> for Mesh {
-    fn into(self) -> CpuMesh {
-        let positions = Positions::F64(self.verts().iter().map(|v| v.coord.into()).collect());
-        let indices = Indices::U32(self.tri_inds().flatten().collect());
+impl From<Mesh> for CpuMesh {
+    fn from(mesh: Mesh) -> Self {
+        let positions = Positions::F64(mesh.verts().iter().map(|v| v.coord.into()).collect());
+        let indices = Indices::U32(mesh.tri_inds().flatten().collect());
         let mut mesh = CpuMesh {
             positions,
             indices,
@@ -102,6 +101,20 @@ impl Into<CpuMesh> for Mesh {
         mesh
     }
 }
+
+// impl Into<CpuMesh> for Mesh {
+//     fn into(self) -> CpuMesh {
+//         let positions = Positions::F64(self.verts().iter().map(|v| v.coord.into()).collect());
+//         let indices = Indices::U32(self.tri_inds().flatten().collect());
+//         let mut mesh = CpuMesh {
+//             positions,
+//             indices,
+//             ..Default::default()
+//         };
+//         mesh.compute_normals();
+//         mesh
+//     }
+// }
 
 impl Mesh {
     pub fn plot(self) -> ! {
@@ -329,7 +342,7 @@ pub fn vertex_transformations(cpu_mesh: &CpuMesh) -> Instances {
             .positions
             .to_f32()
             .into_iter()
-            .map(|p| Mat4::from_translation(p))
+            .map(Mat4::from_translation)
             .collect(),
         ..Default::default()
     }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use crate::{Mesh, Point};
+use crate::{Coord, Mesh};
 // use std::collections::HashMap;
-use three_d::{renderer::*, FrameInputGenerator, Mesh as GPUMesh, WindowedContext};
+use three_d::{renderer::*, FrameInputGenerator, Mesh as GPUMesh, Srgba as Color, WindowedContext};
 use winit::{
     self,
     // event_loop::EventLoop,
@@ -83,7 +83,7 @@ impl WireFrame {
     }
 }
 
-impl Into<Vector3<f64>> for Point {
+impl Into<Vector3<f64>> for Coord {
     fn into(self) -> Vector3<f64> {
         Vector3::new(self.x, self.y, self.z)
     }


### PR DESCRIPTION
- cleanup
- init plane intersection
- init edge plane intersect
- split at coordinate
- demo split at coord
- bump and clean deps
- init split with plane
- added bacon script to help with LD_PATH + cleanup
- init bacon config
- fixver
- init impl split mesh with plane
- kiss for tri
- buggy impl of refine with plane
- added a debug display format
- From instead Into
- cleanup
- dont impl div_inplace as a trait. It is confusing
- added primative cube
- cleanup
- fixed bugg: split edge did not update prev-connectivity
- fixed incorrect use of local vert id
- use new api
- simple main
- test split_plane
- better name for subdividing mesh along a plane
- better name
- remove dbg prints
